### PR TITLE
docker: fix build following change in the Firmware build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ git clone https://github.com/PX4/avoidance.git
 catkin build -w ~/catkin_ws
 ```
 
-Note that you can build it in release mode this way:
+If it fails, try to build again. It seems like it sometimes fails in an undeterministic way.
+
+Note that you can build the node in release mode this way:
 
 ```bash
 catkin build -w ~/catkin_ws --cmake-args -DCMAKE_BUILD_TYPE=Release
@@ -102,7 +104,7 @@ export GAZEBO_MODEL_PATH=${GAZEBO_MODEL_PATH}:~/catkin_ws/src/avoidance/node/mod
 export QT_X11_NO_MITSHM=1
 
 # Setup some more Gazebo-related environment variables
-. ~/Firmware/Tools/setup_gazebo.bash ~/Firmware ~/Firmware/build_posix_sitl_default
+. ~/Firmware/Tools/setup_gazebo.bash ~/Firmware ~/Firmware/build/posix_sitl_default
 
 # Build and run simulation
 make posix_sitl_default gazebo

--- a/docker/sitl-gui/entrypoint.sh
+++ b/docker/sitl-gui/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 source /opt/ros/kinetic/setup.bash
-source ${FIRMWARE_DIR}/Tools/setup_gazebo.bash ${FIRMWARE_DIR} ${FIRMWARE_DIR}/build_posix_sitl_default
+source ${FIRMWARE_DIR}/Tools/setup_gazebo.bash ${FIRMWARE_DIR} ${FIRMWARE_DIR}/build/posix_sitl_default
 
 export ROS_MASTER_URI=http://mavros-avoidance:11311
 

--- a/docker/sitl-server/Dockerfile
+++ b/docker/sitl-server/Dockerfile
@@ -23,7 +23,7 @@ ENV GAZEBO_MODEL_PATH ${GAZEBO_MODEL_PATH}:${AVOIDANCE_DIR}/models
 
 RUN ["/bin/bash", "-c", " \
         cd ${FIRMWARE_DIR} && \
-        . ${FIRMWARE_DIR}/Tools/setup_gazebo.bash ${FIRMWARE_DIR} ${FIRMWARE_DIR}/build_posix_sitl_default && \
+        . ${FIRMWARE_DIR}/Tools/setup_gazebo.bash ${FIRMWARE_DIR} ${FIRMWARE_DIR}/build/posix_sitl_default && \
         DONT_RUN=1 make posix_sitl_default gazebo \
 "]
 
@@ -32,7 +32,7 @@ RUN echo "param set MAV_BROADCAST 1" >> ${FIRMWARE_DIR}/posix-configs/SITL/init/
 CMD ["/bin/bash", "-c", " \
     source /opt/ros/kinetic/setup.bash && \
     export ROS_PACKAGE_PATH=${ROS_PACKAGE_PATH}:${FIRMWARE_DIR} && \
-    . ${FIRMWARE_DIR}/Tools/setup_gazebo.bash ${FIRMWARE_DIR} ${FIRMWARE_DIR}/build_posix_sitl_default && \
+    . ${FIRMWARE_DIR}/Tools/setup_gazebo.bash ${FIRMWARE_DIR} ${FIRMWARE_DIR}/build/posix_sitl_default && \
     export ROS_MASTER_URI=http://mavros-avoidance:11311 && \
     export ROS_IP=`hostname -I` && \
     roslaunch ${WORKSPACE_DIR}/px4_gazebo.launch gui:=false \

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -63,9 +63,10 @@ RUN apt-get update && \
 # Prepare and build avoidance
 COPY node ${AVOIDANCE_DIR}
 
+# NOTE: catkin build fails the first time (maybe the modules have to be built in the right order?)
 RUN ["/bin/bash", "-c", "\
     source /opt/ros/kinetic/setup.bash && \
-    catkin build -w ${CATKIN_WS} \
+    catkin build -w ${CATKIN_WS}; catkin build -w ${CATKIN_WS} \
 "]
 
 # Checkout and build Firmware
@@ -86,7 +87,7 @@ ENV QT_X11_NO_MITSHM=1
 
 RUN ["/bin/bash", "-c", " \
     cd ${FIRMWARE_DIR} && \
-    . ${FIRMWARE_DIR}/Tools/setup_gazebo.bash ${FIRMWARE_DIR} ${FIRMWARE_DIR}/build_posix_sitl_default && \
+    . ${FIRMWARE_DIR}/Tools/setup_gazebo.bash ${FIRMWARE_DIR} ${FIRMWARE_DIR}/build/posix_sitl_default && \
     DONT_RUN=1 make posix_sitl_default gazebo \
 "]
 
@@ -95,6 +96,6 @@ CMD ["/bin/bash", "-c", " \
     source /opt/ros/kinetic/setup.bash && \
     source ${CATKIN_WS}/devel/setup.bash && \
     export ROS_PACKAGE_PATH=${ROS_PACKAGE_PATH}:${FIRMWARE_DIR} && \
-    . ${FIRMWARE_DIR}/Tools/setup_gazebo.bash ${FIRMWARE_DIR} ${FIRMWARE_DIR}/build_posix_sitl_default && \
+    . ${FIRMWARE_DIR}/Tools/setup_gazebo.bash ${FIRMWARE_DIR} ${FIRMWARE_DIR}/build/posix_sitl_default && \
     roslaunch avoidance global_planner_sitl_mavros.launch \
 "]


### PR DESCRIPTION
Running `$ make posix_sitl_default gazebo` was building in `Firmware/build_posix_sitl_default` and now builds in `Firmware/build/posix_sitl_default`. This has to be reflected in the Dockerfiles here.