### PR TITLE
docker: mount ros logs on host

### DIFF
--- a/docker/components/local-planner-node/entrypoint.sh
+++ b/docker/components/local-planner-node/entrypoint.sh
@@ -7,4 +7,7 @@ export ROS_IP=`hostname -I`
 # Wait until ROS master is started
 until rostopic list; do sleep 1; done
 
-roslaunch /root/launch/${1} $2
+LAUNCH_FILE=$1
+shift
+
+roslaunch /root/launch/${LAUNCH_FILE} $@ start_time:="$(date +'%Y%m%d_%I%M%S')"

--- a/docker/components/sitl-server/Dockerfile
+++ b/docker/components/sitl-server/Dockerfile
@@ -11,6 +11,7 @@ ENV WORLDS_DIR ${SIM_DIR}/worlds
 RUN apt-get update && \
     apt-get install -y libopencv-dev \
                        python-jinja2 \
+                       python-toml \
                        protobuf-compiler
 
 RUN git clone https://github.com/PX4/Firmware.git ${FIRMWARE_DIR}

--- a/docker/local_planner/local-planner-prod/local-planner-prod-debug/docker-compose.yml
+++ b/docker/local_planner/local-planner-prod/local-planner-prod-debug/docker-compose.yml
@@ -24,6 +24,8 @@ services:
             - realsense-node
         environment:
             - ROS_MASTER_URI=http://mavros-avoidance:11311
+        volumes:
+            - /logs:/root/.ros
         command: local_avoidance.launch use_sim_time:="false"
     alpinevpn:
         extends:


### PR DESCRIPTION
* mount ~/.ros from local-planner-node on /logs when running in prod-debug
* add required dependency to sitl-server

@baumanta: With this patch, when running the local planner in prod-debug, `~/.ros` will be saved on `/logs` on the Yocto of the Aero. Note that you will have to manually remove them to save space!

Fixes #47.