### PR TITLE
Logs Revision

### DIFF
--- a/docker/components/local-planner-node/launch/local_avoidance.launch
+++ b/docker/components/local-planner-node/launch/local_avoidance.launch
@@ -14,6 +14,6 @@
     </node>
 
     <!-- Logging -->
-    <node pkg="rosbag" type="record" name="log_bag" args="record -O log_$(arg start_time) /mavros/local_position/pose /mavros/local_position/velocity /goal_position /camera/depth/points /local_pointcloud /blocked_marker /rejected_marker /candidates_marker /selected_marker /current_setpoint --split --size 500 --max-splits 5" if="$(arg record_bag)" />
+    <node pkg="rosbag" type="record" name="log_bag" args="record -O log_$(arg start_time) /mavros/local_position/pose /mavros/local_position/velocity /goal_position /local_pointcloud /reprojected_points /blocked_marker /rejected_marker /candidates_marker /selected_marker /current_setpoint --size 3000" if="$(arg record_bag)" />
 
 </launch>


### PR DESCRIPTION
In yesterday flight we have seen that the bag files record a too small amount of time to understand what's going on. Therefore:
- I removed the `/camera/depth/points` that logs the entire point cloud
- I added `/reprojected_points` that together with `/local_pointcloud` gives what the UAV is avoiding
- I create one log of 3000MB instead of 6 logs of 500MB each. 