### PR TITLE
docker: install mavros from official package instead of sources

### DIFF
--- a/docker/components/mavros-avoidance/entrypoint.sh
+++ b/docker/components/mavros-avoidance/entrypoint.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 
-source ~/catkin_ws/devel/setup.bash
-export ROS_IP=`hostname -I`
-export ROS_MASTER_URI=http://`hostname -I`:11311
+source /opt/ros/${ROS_DISTRO}/setup.bash
+export ROS_IP=${ROS_IP:-`hostname -I`}
+export ROS_MASTER_URI=${ROS_MASTER_URI:-http://`hostname -I`:11311}
 
 roscore -p 11311 &
 sleep 1
-rosparam set use_sim_time true
 
 roslaunch mavros -p 11311 px4.launch $1

--- a/docker/components/mavros/Dockerfile
+++ b/docker/components/mavros/Dockerfile
@@ -1,23 +1,9 @@
-FROM ros:kinetic-ros-core
-
-# Installation instructions: https://dev.px4.io/en/ros/mavros_installation.html
+FROM ros:kinetic-ros-base
 
 RUN apt-get update && \
-    apt-get install -y python-wstool \
-                       python-rosinstall-generator \
-                       python-catkin-tools && \
-    mkdir -p ~/catkin_ws/src && \
-    catkin init --workspace ~/catkin_ws && \
-    wstool init ~/catkin_ws/src && \
-    rosinstall_generator --upstream mavros | tee /tmp/mavros.rosinstall && \
-    rosinstall_generator mavlink | tee -a /tmp/mavros.rosinstall && \
-    wstool merge -t ~/catkin_ws/src /tmp/mavros.rosinstall && \
-    wstool update -t ~/catkin_ws/src && \
-    rosdep install --from-paths ~/catkin_ws/src --ignore-src --rosdistro kinetic -y
+    apt-get install -y ros-kinetic-mavros
 
-RUN ["/bin/bash", "-c", "source /opt/ros/kinetic/setup.bash && catkin build --workspace ~/catkin_ws"]
-
-RUN ~/catkin_ws/src/mavros/mavros/scripts/install_geographiclib_datasets.sh
+RUN /opt/ros/${ROS_DISTRO}/lib/mavros/install_geographiclib_datasets.sh
 
 COPY entrypoint.sh /root/entrypoint.sh
 RUN chmod +x /root/entrypoint.sh

--- a/docker/components/mavros/entrypoint.sh
+++ b/docker/components/mavros/entrypoint.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 
-source ~/catkin_ws/devel/setup.bash
-export ROS_IP=`hostname -I`
-export ROS_MASTER_URI=http://`hostname -I`:11311
-
-roscore -p 11311 &
-sleep 1
-rosparam set use_sim_time true
+source /opt/ros/${ROS_DISTRO}/setup.bash
+export ROS_IP=${ROS_IP:-`hostname -I`}
+export ROS_MASTER_URI=${ROS_MASTER_URI:-http://`hostname -I`:11311}
 
 roslaunch mavros -p 11311 px4.launch $1


### PR DESCRIPTION
There does not seem to be a reason for compiling mavros from sources, so using the official package is better.