### PR TITLE
docker: run.sh should fail when docker-compose fails

### DIFF
--- a/docker/global_planner/global-planner-prod/global-planner-prod-debug/run.sh
+++ b/docker/global_planner/global-planner-prod/global-planner-prod-debug/run.sh
@@ -2,7 +2,7 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-docker-compose -f ${DIR}/docker-compose.yml up -d
+docker-compose -f ${DIR}/docker-compose.yml up -d || { exit 1; }
 
 VPN_SERVER_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' globalplannerproddebug_alpinevpn_1)
 ROS_MASTER_URI=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' globalplannerproddebug_mavros-avoidance_1)

--- a/docker/local_planner/local-planner-prod/local-planner-prod-debug/run.sh
+++ b/docker/local_planner/local-planner-prod/local-planner-prod-debug/run.sh
@@ -2,7 +2,7 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-docker-compose -f ${DIR}/docker-compose.yml up -d
+docker-compose -f ${DIR}/docker-compose.yml up -d || { exit 1; }
 
 VPN_SERVER_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' localplannerproddebug_alpinevpn_1)
 ROS_MASTER_URI=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' localplannerproddebug_mavros-avoidance_1)


### PR DESCRIPTION
The effect of this change is that if `docker-compose` fails to start the containers, the run script fails instead of showing instructions and logs. Consequently, the terminal output is more readable.