### PR TITLE
fix nasty race condition in global planner 

### DIFF
--- a/docker/demo/ubuntu/Dockerfile
+++ b/docker/demo/ubuntu/Dockerfile
@@ -81,8 +81,9 @@ ENV GAZEBO_MODEL_PATH ${GAZEBO_MODEL_PATH}:${MODELS_DIR}
 
 RUN apt-get update && \
     apt-get install -y libopencv-dev \
+                       protobuf-compiler \
                        python-jinja2 \
-                       protobuf-compiler
+                       python-toml
 
 ENV QT_X11_NO_MITSHM=1
 

--- a/global_planner/CMakeLists.txt
+++ b/global_planner/CMakeLists.txt
@@ -151,7 +151,7 @@ add_executable(path_handler_node src/nodes/path_handler_node.cpp)
 
 ## Add cmake target dependencies of the executable
 ## same as for the library above
-# add_dependencies(avoidance_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(path_handler_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(global_planner_node


### PR DESCRIPTION
* nasty race condition in the CMakeLists.txt of global planner
* trivial issue in docker demo

The fix for the race condition is documented [here](http://docs.ros.org/lunar/api/catkin/html/howto/format2/dynamic_reconfiguration.html) and [here](http://wiki.ros.org/dynamic_reconfigure/Tutorials/HowToWriteYourFirstCfgFile).