### PR TITLE
GlobalPlanner send companion status

### DIFF
--- a/global_planner/src/nodes/path_handler_node.cpp
+++ b/global_planner/src/nodes/path_handler_node.cpp
@@ -35,6 +35,9 @@ PathHandlerNode::PathHandlerNode() {
       nh_.advertise<nav_msgs::Path>("/three_point_path", 10);
   three_point_msg_publisher_ =
       nh_.advertise<global_planner::ThreePointMsg>("/three_point_msg", 10);
+  mavros_system_status_pub_ =
+      nh_.advertise<mavros_msgs::CompanionProcessStatus>(
+          "/mavros/companion_process/status", 1);
   // avoidance_triplet_msg_publisher_ =
   // nh_.advertise<mavros_msgs::AvoidanceTriplet>("/mavros/avoidance_triplet",
   // 10);
@@ -259,6 +262,16 @@ void PathHandlerNode::publishSetpoint() {
   mavros_msgs::Trajectory obst_free_path = {};
   transformPoseToObstacleAvoidance(obst_free_path, setpoint);
   mavros_obstacle_free_path_pub_.publish(obst_free_path);
+  publishSystemStatus();
+}
+
+// Publish companion process status
+void PathHandlerNode::publishSystemStatus() {
+  mavros_msgs::CompanionProcessStatus status_msg;
+  status_msg.header.stamp = ros::Time::now();
+  status_msg.component = 196;  // MAV_COMPONENT_ID_AVOIDANCE
+  status_msg.state = static_cast<int>(MAV_STATE::MAV_STATE_ACTIVE);
+  mavros_system_status_pub_.publish(status_msg);
 }
 
 // Send a 3-point message representing the current path

--- a/global_planner/src/nodes/path_handler_node.h
+++ b/global_planner/src/nodes/path_handler_node.h
@@ -9,6 +9,8 @@
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
 #include <geometry_msgs/Vector3.h>
+
+#include <mavros_msgs/CompanionProcessStatus.h>
 #include <mavros_msgs/Trajectory.h>
 #include <nav_msgs/Path.h>
 #include <ros/ros.h>
@@ -22,6 +24,18 @@
 #include <global_planner/ThreePointMsg.h>
 
 namespace global_planner {
+
+enum class MAV_STATE {
+  MAV_STATE_UNINIT,
+  MAV_STATE_BOOT,
+  MAV_STATE_CALIBRATIN,
+  MAV_STATE_STANDBY,
+  MAV_STATE_ACTIVE,
+  MAV_STATE_CRITICAL,
+  MAV_STATE_EMERGENCY,
+  MAV_STATE_POWEROFF,
+  MAV_STATE_FLIGHT_TERMINATION,
+};
 
 class PathHandlerNode {
  public:
@@ -62,6 +76,7 @@ class PathHandlerNode {
   ros::Publisher three_point_msg_publisher_;
   ros::Publisher avoidance_triplet_msg_publisher_;
   ros::Publisher mavros_obstacle_free_path_pub_;
+  ros::Publisher mavros_system_status_pub_;
 
   tf::TransformListener listener_;
 
@@ -84,6 +99,7 @@ class PathHandlerNode {
                                         geometry_msgs::PoseStamped pose);
   void publishSetpoint();
   void publishThreePointMsg();
+  void publishSystemStatus();
 };
 
 }  // namespace global_planner


### PR DESCRIPTION
This PR enables to run the Global Planner in mission mode on Firmware master.
Currently the preflight checks are failing because the planner doesn't send its state