### PR TITLE
improve avoidance node to use ROS2

### DIFF
--- a/avoidance/include/avoidance/avoidance_node.h
+++ b/avoidance/include/avoidance/avoidance_node.h
@@ -40,9 +40,15 @@ class AvoidanceNode {
 
   rclcpp::executors::MultiThreadedExecutor cmdloop_executor_;
   rclcpp::executors::MultiThreadedExecutor statusloop_executor_;
-
+  
   rclcpp::TimerBase::SharedPtr cmdloop_timer_;
   rclcpp::TimerBase::SharedPtr statusloop_timer_;
+
+  std::thread* statusloop_thread;
+  std::thread* cmdloop_thread;
+  
+  rclcpp::Node::SharedPtr avoidance_node_status;
+  rclcpp::Node::SharedPtr avoidance_node_cmd;
 
   MAV_STATE companion_state_ = MAV_STATE::MAV_STATE_STANDBY;
 

--- a/avoidance/src/transform_buffer.cpp
+++ b/avoidance/src/transform_buffer.cpp
@@ -26,9 +26,10 @@ bool TransformBuffer::interpolateTransform(const geometry_msgs::msg::TransformSt
   tf2::Vector3 tf_earlier_translation;
   tf2::Quaternion tf_earlier_rotation;
   tf2::Quaternion tf_later_rotation;
-  tf2::fromMsg(tf_earlier_translation, tf_earlier.transform.translation);
-  tf2::fromMsg(tf_earlier_rotation, tf_earlier.transform.rotation);
-  tf2::fromMsg(tf_later_rotation, tf_later.transform.rotation);
+  tf_earlier_translation.setValue(tf_earlier.transform.translation.x, tf_earlier.transform.translation.y, tf_earlier.transform.translation.z);
+  // tf2::fromMsg(tf_earlier.transform.translation, tf_earlier_translation);
+  tf2::fromMsg(tf_earlier.transform.rotation, tf_earlier_rotation);
+  tf2::fromMsg(tf_later.transform.rotation, tf_later_rotation);
 
   const tf2::Vector3 translation = tf_earlier_translation * (1.f - tau) + tf_earlier_translation * tau;
   const tf2::Quaternion rotation = tf_earlier_rotation.slerp(tf_later_rotation, tau);


### PR DESCRIPTION
I am working on to use PX4-Avoidance global_planner in ROS2 environment.

Until now, I succeed with subscribing a topic(VehicleLocalPosition) in ROS2 environment.

The avoidance node should be changed to the following reasons.
- In current form, the two avoidance nodes(avoidance_node_cmd, avoidance_node_status) spinning and it stuck with executor.join() function. Thus, I made thread/related variables as global variable to make it spin in the background.
- tf2::fromMsg usage was fault. I change the order of input parameters but I failed to use "tf2::fromMsg(tf_earlier.transform.translation, tf_earlier_translation);". In tf2 documentation, there is a declaration about geometry_msgs::msg::Vector3 and tf2::Vector3 but it is not working.. So I changed it to "tf_earlier_translation.setValue(tf_earlier.transform.translation.x, tf_earlier.transform.translation.y, tf_earlier.transform.translation.z);" as directly assign Vector3 values to tf_earlier_translation. (Please give a comment about this)

The message type of mavros and px4_msgs in ROS2 is quite different so I thinks its little bit hard work to porting global_planner to ROS2 environment but I will try to solve it.