### PR TITLE
add missing install note for rosdep to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ You might want to skip some steps if your system is already partially installed.
    # for ros-melodic install:
    sudo apt install python-rosdep
    # for ros-noetic install: 
-   sudo apt install pyhton3-rosdep
+   sudo apt install python3-rosdep
 
    rosdep init
    rosdep update

--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ You might want to skip some steps if your system is already partially installed.
 
 1. Install and initialize rosdep.
    ```bash
-   sudo apt install python-rosdep
+   # for ros-melodic install:
+   sudo apt install pyhton-rosdep
+   # for ros-noetic install: 
+   sudo apt install pyhton3-rosdep
 
    rosdep init
    rosdep update

--- a/README.md
+++ b/README.md
@@ -82,8 +82,10 @@ You might want to skip some steps if your system is already partially installed.
        sudo apt install ros-melodic-gazebo9-*
        ```
 
-1. Initialize rosdep.
+1. Install and initialize rosdep.
    ```bash
+   sudo apt install python-rosdep
+
    rosdep init
    rosdep update
    ```

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ You might want to skip some steps if your system is already partially installed.
 1. Install and initialize rosdep.
    ```bash
    # for ros-melodic install:
-   sudo apt install pyhton-rosdep
+   sudo apt install python-rosdep
    # for ros-noetic install: 
    sudo apt install pyhton3-rosdep
 


### PR DESCRIPTION
During my recent install of the avoidance module on Ubuntu 18.04, I discovered a missing install to run rosdep. I think that is due to the fact, that python-rosdep is no longer included in the ros-melodic-desktop-full install.  I just added this to the README 