### PR TITLE
Fix local_planner config path after #483

### DIFF
--- a/local_planner/launch/local_planner_aero.launch
+++ b/local_planner/launch/local_planner_aero.launch
@@ -14,7 +14,7 @@
         <include file="$(find mavros)/launch/node.launch">
             <arg name="pluginlists_yaml" value="$(find mavros)/launch/px4_pluginlists.yaml" />
             <!-- Need to change the config file to get the tf topic and get local position in terms of local origin -->
-            <arg name="config_yaml" value="$(find local_planner)/resource/px4_config.yaml" />
+            <arg name="config_yaml" value="$(find avoidance)/resource/px4_config.yaml" />
             <arg name="fcu_url" value="$(arg fcu_url)" />
             <arg name="gcs_url" value="$(arg gcs_url)" />
             <arg name="tgt_system" value="$(arg tgt_system)" />

--- a/local_planner/launch/local_planner_aeroD415.launch
+++ b/local_planner/launch/local_planner_aeroD415.launch
@@ -14,7 +14,7 @@
         <include file="$(find mavros)/launch/node.launch">
             <arg name="pluginlists_yaml" value="$(find mavros)/launch/px4_pluginlists.yaml" />
             <!-- Need to change the config file to get the tf topic and get local position in terms of local origin -->
-            <arg name="config_yaml" value="$(find local_planner)/resource/px4_config.yaml" />
+            <arg name="config_yaml" value="$(find avoidance)/resource/px4_config.yaml" />
             <arg name="fcu_url" value="$(arg fcu_url)" />
             <arg name="gcs_url" value="$(arg gcs_url)" />
             <arg name="tgt_system" value="$(arg tgt_system)" />

--- a/local_planner/launch/mavros.launch
+++ b/local_planner/launch/mavros.launch
@@ -14,7 +14,7 @@
         <include file="$(find mavros)/launch/node.launch">
             <arg name="pluginlists_yaml" value="$(find mavros)/launch/px4_pluginlists.yaml" />
             <!-- Need to change the config file to get the tf topic and get local position in terms of local origin -->
-            <arg name="config_yaml" value="$(find local_planner)/resource/px4_config.yaml" />
+            <arg name="config_yaml" value="$(find avoidance)/resource/px4_config.yaml" />
             <arg name="fcu_url" value="$(arg fcu_url)" />
             <arg name="gcs_url" value="$(arg gcs_url)" />
             <arg name="tgt_system" value="$(arg tgt_system)" />


### PR DESCRIPTION
`local_planner/resource/px4_config.yaml` already moved to `avoidance/resource/px4_config.yaml` in #483 but there is there config files forgot to change the path. Here is the fix.