### PR TITLE
Fix Travis CI after repo name changed to PX4-Avoidance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ script:
   - catkin build
   - source ~/catkin_ws/devel/setup.bash
   # Check for clang format
-  - cd src/avoidance
+  - cd src/PX4-Avoidance
   - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
   - (cd tools && ./check_state_machine_diagrams.sh)
   - catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -DCATKIN_ENABLE_TESTING=False -DDISABLE_SIMULATION=ON && catkin build


### PR DESCRIPTION
Actually I don't know how exactly Travis works, but I get this will fix the CI fail. 
If I was wrong please leave comment below.